### PR TITLE
Hotfix for error when unexpected cookie exists

### DIFF
--- a/cambio/utils/schemas.py
+++ b/cambio/utils/schemas.py
@@ -1,5 +1,5 @@
 """
-By Daniel Neshyba-Rowe
+By Daniel Neshyba-Rowe and Penny Rowe
 2022/12/21
 """
 
@@ -26,6 +26,7 @@ class BaseInputs(BaseModel):
         """
         Replace default inputs to CAMBIO with user-defined values
         """
+
         input_dict_cleaned = clean_dict(input_dict)
         try:
             return cls.parse_obj(input_dict_cleaned)
@@ -39,7 +40,21 @@ class BaseInputs(BaseModel):
         """
         # TODO: investigate possibilities of malicious code injection via json deserialization
         input_dict = json.loads(input_json)
+
         return cls.from_dict(input_dict)
+
+    @classmethod
+    def is_json(cls, possible_json: str) -> bool:
+        """
+        Determine if a string is valid json
+        @param possible_json  The input to test
+        @returns  True if json, else false
+        """
+        try:
+            json.loads(possible_json)
+        except ValueError as e:
+            return False
+        return True
 
 
 class CambioInputs(BaseInputs):

--- a/cambio/views.py
+++ b/cambio/views.py
@@ -5,9 +5,6 @@ By Penny Rowe and Daniel Neshyba-Rowe
 Inspired by Benchly, by Ben Gamble, Charlie Dahl, and Penny Rowe
 """
 
-import json
-
-from typing import Any
 from django.shortcuts import render
 from django.http import HttpRequest, HttpResponse
 
@@ -69,7 +66,7 @@ def index(request: HttpRequest) -> HttpResponse:
     # TODO List
     # No need to run climate model for the default (but this may be moot)
     # Change the constrain albedo business so that if False, to make unconstrained = False or True
-    # It would be nice to be able to rename scenarios, and also have a way to add a notes elaborating on them
+    # It would be nice to be able to rename scenarios, and also add a notes elaborating on them
     # When curves are right on top of one another, it would be useful to differentiate them
     # Remove start/stop year and dtime from display for added scenarios
     # Improve variable names under Add new scenario
@@ -90,7 +87,9 @@ def index(request: HttpRequest) -> HttpResponse:
     include_default(scenario_inputs, default)
     # - Then add old scenarios from cookies
     for scenario_id, scenario in request.COOKIES.items():
-        scenario_inputs[scenario_id] = CambioInputs.from_json(scenario)
+        if CambioInputs.is_json(scenario):
+            scenario_inputs[scenario_id] = CambioInputs.from_json(scenario)
+
     # - Finally, get new scenario from get parameters only if it exists
     new_scenario_id = request.GET.get("scenario_name", "")
     if new_scenario_id != "":


### PR DESCRIPTION
To see how this fixes the cookie bug:

Duplicate the cookie bug: Run the app locally. Try to log in at 127.0.0.1:8000/admin.  It will not work, but it will create a cookie.  Go back to 127.0.0.1:8000/cambio and refesh.  An error will occur as the app tries to process the bad cookie.

After pulling this branch, repeat the above and the error should not occur.